### PR TITLE
Add nvim-navic plugin highlights

### DIFF
--- a/lua/pywal16/config.lua
+++ b/lua/pywal16/config.lua
@@ -262,6 +262,36 @@ M.highlights_base = function(colors)
     -- nvim-scrollbar
     ScrollbarHandle = { bg = colors.color2 },
     ScrollbarCursorHandle = { bg = colors.color12 },
+
+    -- nvim-navic
+    NavicIconsFile = { bg = colors.transparent, fg = colors.color2},
+    NavicIconsModule = { bg = colors.transparent, fg = colors.color3},
+    NavicIconsNamespace = { bg = colors.transparent, fg = colors.color2},
+    NavicIconsPackage = { bg = colors.transparent, fg = colors.color3},
+    NavicIconsClass = { bg = colors.transparent, fg = colors.color2},
+    NavicIconsMethod = { bg = colors.transparent, fg = colors.color3},
+    NavicIconsProperty = { bg = colors.transparent, fg = colors.color7},
+    NavicIconsField = { bg = colors.transparent, fg = colors.color8},
+    NavicIconsConstructor = { bg = colors.transparent, fg = colors.color9},
+    NavicIconsEnum = { bg = colors.transparent, fg = colors.color10},
+    NavicIconsInterface = { bg = colors.transparent, fg = colors.color11},
+    NavicIconsFunction = { bg = colors.transparent, fg = colors.color12},
+    NavicIconsVariable = { bg = colors.transparent, fg = colors.color13},
+    NavicIconsConstant = { bg = colors.transparent, fg = colors.color14},
+    NavicIconsString = { bg = colors.transparent, fg = colors.color15},
+    NavicIconsNumber = { bg = colors.transparent, fg = colors.color1},
+    NavicIconsBoolean = { bg = colors.transparent, fg = colors.color2},
+    NavicIconsArray = { bg = colors.transparent, fg = colors.color3},
+    NavicIconsObject = { bg = colors.transparent, fg = colors.color4},
+    NavicIconsKey = { bg = colors.transparent, fg = colors.color5},
+    NavicIconsNull = { bg = colors.transparent, fg = colors.color6},
+    NavicIconsEnumMember = { bg = colors.transparent, fg = colors.color7},
+    NavicIconsStruct = { bg = colors.transparent, fg = colors.color8},
+    NavicIconsEvent = { bg = colors.transparent, fg = colors.color9},
+    NavicIconsOperator = { bg = colors.transparent, fg = colors.color10},
+    NavicIconsTypeParameter = { bg = colors.transparent, fg = colors.color11},
+    NavicText = { bg = colors.transparent, fg = colors.foreground},
+    NavicSeparator = { bg = colors.transparent, fg = colors.foreground},
   }
 end
 


### PR DESCRIPTION
This plugin adds the capability to to show breadcrumbs for the current location of the cursor in the context:

![image](https://github.com/uZer/pywal16.nvim/assets/55515322/015bab3c-f3a1-429b-b624-d28066c4659d)
(Demo of the edited highlights)

Feel free to edit the colors if they can be improved.