### PR TITLE
check $XDG_CACHE_HOME first, fallback to $HOME/.cache

### DIFF
--- a/lua/pywal16/core.lua
+++ b/lua/pywal16/core.lua
@@ -1,30 +1,38 @@
 local M = {}
 
 function M.get_colors()
-  vim.cmd [[ source $HOME/.cache/wal/colors-wal.vim ]]
+	local cache_dir = os.getenv("XDG_CACHE_HOME") or (os.getenv("HOME") .. "/.cache")
+	local colors_path = cache_dir .. "/wal/colors-wal.vim"
 
-  return {
-    transparent = "NONE",
-    background = vim.g.background,
-    foreground = vim.g.foreground,
-    cursor = vim.g.cursor,
-    color0 = vim.g.color0,
-    color1 = vim.g.color1,
-    color2 = vim.g.color2,
-    color3 = vim.g.color3,
-    color4 = vim.g.color4,
-    color5 = vim.g.color5,
-    color6 = vim.g.color6,
-    color7 = vim.g.color7,
-    color8 = vim.g.color8,
-    color9 = vim.g.color9,
-    color10 = vim.g.color10,
-    color11 = vim.g.color11,
-    color12 = vim.g.color12,
-    color13 = vim.g.color13,
-    color14 = vim.g.color14,
-    color15 = vim.g.color15,
-  }
+	if vim.fn.filereadable(colors_path) == 1 then
+		vim.cmd("source " .. colors_path)
+	else
+		vim.notify("couldn't read wal colors, file does not exist." .. colors_path, vim.log.levels.WARN)
+		return {}
+	end
+
+	return {
+		transparent = "NONE",
+		background = vim.g.background,
+		foreground = vim.g.foreground,
+		cursor = vim.g.cursor,
+		color0 = vim.g.color0,
+		color1 = vim.g.color1,
+		color2 = vim.g.color2,
+		color3 = vim.g.color3,
+		color4 = vim.g.color4,
+		color5 = vim.g.color5,
+		color6 = vim.g.color6,
+		color7 = vim.g.color7,
+		color8 = vim.g.color8,
+		color9 = vim.g.color9,
+		color10 = vim.g.color10,
+		color11 = vim.g.color11,
+		color12 = vim.g.color12,
+		color13 = vim.g.color13,
+		color14 = vim.g.color14,
+		color15 = vim.g.color15,
+	}
 end
 
 return M


### PR DESCRIPTION
pretty straightforward change, just check `$XDG_CACHE_HOME` first, then fallback to `$HOME/.cache`

The reason behind is that I'm on Windows and I set `$XDG_CACHE_HOME` so Linux-y tools behave just like a *sane* Windows tool would.