### PR TITLE
add: `custom_outdir` from latest version of pywal16

### DIFF
--- a/lua/pywal16/core.lua
+++ b/lua/pywal16/core.lua
@@ -1,13 +1,13 @@
 local M = {}
 
 function M.get_colors()
-  local config_path_env = os.getenv("PYWAL_CACHE_DIR") .. "/colors-wal.vim"
-  local config_path_def = os.getenv("HOME") .. ".cache/wal/colors-wal.vim"
-
-  if vim.fn.filereadable(config_path_env) == 1 then
-    vim.cmd("source " .. config_path_env)
+  local cache_dir = os.getenv("PYWAL_CACHE_DIR") or os.getenv("XDG_CACHE_HOME") or (os.getenv("HOME") .. "/.cache")
+  local colors_path = cache_dir .. "/wal/colors-wal.vim"
+  if vim.fn.filereadable(colors_path) == 1 then
+    vim.cmd("source " .. colors_path)
   else
-    vim.cmd("source " .. config_path_def)
+    vim.notify("couldn't read wal colors, file does not exist." .. colors_path, vim.log.levels.WARN)
+    return {}
   end
 
   return {

--- a/lua/pywal16/core.lua
+++ b/lua/pywal16/core.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 function M.get_colors()
-  local config_path_env = os.getenv("PYWAL16_OUT_DIR") .. "/colors-wal.vim"
+  local config_path_env = os.getenv("PYWAL_CACHE_DIR") .. "/colors-wal.vim"
   local config_path_def = os.getenv("HOME") .. ".cache/wal/colors-wal.vim"
 
   if vim.fn.filereadable(config_path_env) == 1 then

--- a/lua/pywal16/core.lua
+++ b/lua/pywal16/core.lua
@@ -1,7 +1,14 @@
 local M = {}
 
 function M.get_colors()
-  vim.cmd [[ source $HOME/.cache/wal/colors-wal.vim ]]
+  local config_path_env = os.getenv("PYWAL16_OUT_DIR") .. "/colors-wal.vim"
+  local config_path_def = os.getenv("HOME") .. ".cache/wal/colors-wal.vim"
+
+  if vim.fn.filereadable(config_path_env) == 1 then
+    vim.cmd("source " .. config_path_env)
+  else
+    vim.cmd("source " .. config_path_def)
+  end
 
   return {
     transparent = "NONE",


### PR DESCRIPTION
According to pywal16's configuration, you can add custom cache directories other than the default, so when you try to use `PYWAL_CACHE_DIR` this plugin doesn't work since the cache files for pywal16 is moved to `PYWAL_CACHE_DIR`.

````bash
configuration:
pywal16 supports the usage of the following env vars for configuration

env vars:
  XDG_CONFIG_HOME       parent directory to the user wal/templates dir.
  PYWAL_CACHE_DIR       directory for the built templates, default XDG_CACHE_HOME/wal dir.
  NO_FUN                set to 1 to disable eastereggs.
  EASTEREGGS            set to 0 to disable eastereggs, set to 1 to enable them.
````