### PR TITLE
Fix nil concatenation crash when PYWAL_CACHE_DIR or XDG_CACHE_HOME are unset

### DIFF
--- a/lua/pywal16/core.lua
+++ b/lua/pywal16/core.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 function M.get_colors()
-  local cache_dir = os.getenv("XDG_CACHE_HOME") or vim.fn.stdpath("cache")
+  local cache_dir = os.getenv("XDG_CACHE_HOME") or os.getenv("HOME") .. "/.cache"
   local colors_path = (os.getenv("PYWAL_CACHE_DIR") and os.getenv("PYWAL_CACHE_DIR") .. "/colors-wal.vim") or (cache_dir .. "/wal/colors-wal.vim")
   if vim.fn.filereadable(colors_path) == 1 then
     vim.cmd("source " .. colors_path)

--- a/lua/pywal16/core.lua
+++ b/lua/pywal16/core.lua
@@ -1,8 +1,8 @@
 local M = {}
 
 function M.get_colors()
-  local cache_dir =  os.getenv("XDG_CACHE_HOME") or (os.getenv("HOME") .. "/.cache")
-  local colors_path = (os.getenv("PYWAL_CACHE_DIR") .. "/colors-wal.vim") or cache_dir .. "/wal/colors-wal.vim"
+  local cache_dir = os.getenv("XDG_CACHE_HOME") or vim.fn.stdpath("cache")
+  local colors_path = (os.getenv("PYWAL_CACHE_DIR") and os.getenv("PYWAL_CACHE_DIR") .. "/colors-wal.vim") or (cache_dir .. "/wal/colors-wal.vim")
   if vim.fn.filereadable(colors_path) == 1 then
     vim.cmd("source " .. colors_path)
   else


### PR DESCRIPTION
Fix nil concatenation crash in get_colors()

Safely check PYWAL_CACHE_DIR before using it and fall back to
XDG_CACHE_HOME / stdpath("cache") when unset. Prevents startup
crash when environment variables are missing.

This also fixes a regression introduced in #11, which caused `get_colors()` 
to crash when PYWAL_CACHE_DIR or XDG_CACHE_HOME were unset.